### PR TITLE
fix: handle case when month index is 0

### DIFF
--- a/src/lib/date.js
+++ b/src/lib/date.js
@@ -24,7 +24,7 @@ function getNextSalaryDate(salaryDay = 15) {
   const date = new Date();
 
   if (date.getDate() > salaryDay) {
-    date.setMonth(date.getMonth() + 1);
+    date.setMonth(date.getMonth() + 1, 1);
   }
   date.setDate(salaryDay);
   fixSalaryDay(date);


### PR DESCRIPTION
### Changes Made
- Added handling for the case when the month number is 0 in `getNextSalaryDate` function.

### Details
This pull request addresses an issue where the month number becomes 0 (representing January) in the `getNextSalaryDate` function. In JavaScript, months are zero-indexed, with 0 being January and 11 being December.

This change ensures accurate calculations for the last and next salary dates, preventing any issues related to month adjustment.

### Additional Notes
**rewrite with typescript**